### PR TITLE
use ToValue as the bound for captured values

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -9,5 +9,6 @@ fn main() {
     info!("hello {}", "cats", {
         cat_1: "chashu",
         cat_2: "nori",
+        cat_count: 2,
     });
 }


### PR DESCRIPTION
Hi! :wave:

This PR allows any `T: ToValue` to be used as the value in a captured key-value pair instead of just strings. See: https://github.com/rust-lang-nursery/log/pull/353 where we should also make this change.

## Description
Instead of expecting a `&[(&str, &str)]`, we can take a `&[(&str, &dyn ToValue)]`, which still implements the `Source` trait. That way values like integers can also be captured, along with more complex values if they use an adapter.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
