### PR TITLE
Fix log macro compatibility

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ macro_rules! log {
 #[doc(hidden)]
 macro_rules! log_impl {
     // End of macro input
-    (target: $target:expr, $lvl:expr, ($($arg:expr),*)) => {
+    (target: $target:expr, $lvl:expr, ($($arg:expr),*)) => {{
         let lvl = $lvl;
         if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
             $crate::__private_api_log(
@@ -82,10 +82,10 @@ macro_rules! log_impl {
                 None,
             );
         }
-    };
+    }};
 
     // // Trailing k-v pairs containing no trailing comma
-    (target: $target:expr, $lvl:expr, ($($arg:expr),*) { $($key:ident : $value:expr),* }) => {
+    (target: $target:expr, $lvl:expr, ($($arg:expr),*) { $($key:ident : $value:expr),* }) => {{
         if $lvl <= $crate::STATIC_MAX_LEVEL && $lvl <= $crate::max_level() {
             $crate::__private_api_log(
                 __log_format_args!($($arg),*),
@@ -94,7 +94,7 @@ macro_rules! log_impl {
                 Some(&[$((__log_stringify!($key), &$value)),*])
             );
         }
-    };
+    }};
 
     // Trailing k-v pairs with trailing comma
     (target: $target:expr, $lvl:expr, ($($e:expr),*) { $($key:ident : $value:expr,)* }) => {


### PR DESCRIPTION
Fix log macro compatibility

## Description
```
match 0x42 {
    0x42 => kv_log_macro::info!("oh my log"),
    _ => ()
}
```

This code cannot be compiled with `kv-log-macro`.

```
error[E0308]: `match` arms have incompatible types
  --> src/main.rs:82:14
   |
80 | /     match 0x42 {
81 | |         0x42 => kv_log_macro::info!("oh my id"),
   | |                 ------------------------------- this is found to be of type `bool`
82 | |         _ => ()
   | |              ^^ expected `bool`, found `()`
83 | |     }
   | |_____- `match` arms have incompatible types
```



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
