### PR TITLE
Add `std` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ log = { version = "0.4.8", features = ["kv_unstable"] }
 
 [dev-dependencies]
 femme = "1.2.0"
+
+[features]
+std = ["log/std"]


### PR DESCRIPTION
## Description

Simply allows enabling the `std` feature in the `log` crate.

## Motivation and Context

Required to avoid this error

```
 the trait `log::kv::value::ToValue` is not implemented for `std::string::String`
```

Of course it is possible to add `log` dependency additionally to a crate that uses `kv-log-macro`, but that really shouldn't have to be necessary.

Instead of 

```toml
kv-log-macro = "1.0.4"
log = { version = "0.4.8", features = ["std"] }
```

now

```toml
kv-log-macro = { version = "1.0.4", features = ["std"] }
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
