### PR TITLE
Enable `std` feature in `log` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-log = { version = "0.4.8", features = ["kv_unstable"] }
+log = { version = "0.4.8", features = ["kv_unstable", "std"] }
 
 [dev-dependencies]
 femme = "1.2.0"


### PR DESCRIPTION
## Description

Enables the `std` feature in the `log` dependency. This should be perfectly fine since `kv-log-macro` is not `no_std`.

## Motivation and Context

Required to avoid this error

```
 the trait `log::kv::value::ToValue` is not implemented for `std::string::String`
```

Of course it is possible to add `log` dependency additionally to a crate that uses `kv-log-macro`, but that really shouldn't have to be necessary.

Avoids the following in the Cargo manifest.
```toml
[dependencies]
kv-log-macro = "1.0.4"
log = { version = "0.4.8", features = ["std"] }
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
