### PR TITLE
update log to use kv_unstable_std instead of std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-log = { version = "0.4.8", features = ["kv_unstable"] }
+log = { version = "0.4.8", features = ["kv_unstable", "kv_unstable_std"] }
 
 [dev-dependencies]
 femme = "1.2.0"


### PR DESCRIPTION
This is the same as #7, but uses the `kv_unstable_std` feature, which we ended up needing to introduce in `log` to work around some limitations of Cargo features.

Part of https://github.com/rust-lang/log/issues/437

The `log` crate has an unstable structured logging API under the `kv_unstable` feature. In previous releases, if you specified both the `kv_unstable` and `std` features of `log` like so:

```toml
log = { features = ["std", "kv_unstable"]}
```

you'd get support for standard library types in `log`'s structured logging API.

Going forward, this functionality is now gated under `kv_unstable_std`:

```toml
log = { features = ["kv_unstable_std"]}
```

This change was made because we need to enable features in optional dependencies when both the `std` and `kv_unstable` features are enabled, which isn't currently supported by Cargo.

This PR updates this library to follow the new approach. It can be merged at any time and is currently non-blocking, but on 2020-01-18 the version of `log` requiring `kv_unstable_std` instead of `kv_unstable` and `std` will be published.

Thanks for trying out `log`'s structured logging API and sorry for any disruption! :bow: